### PR TITLE
Update zh_cn

### DIFF
--- a/common/src/main/resources/assets/oneironaut/lang/zh_cn.json
+++ b/common/src/main/resources/assets/oneironaut/lang/zh_cn.json
@@ -146,7 +146,7 @@
   "oneironaut.page.wisp_lanterns.6": "释放循环型咒灵时，它会出现在所指方块的旁边。弹射式咒灵则会从我的脸前发射出去，保留捕获前速度（方向不保留）。潜行时使用物品，即可丢弃存储的咒灵。",
   "oneironaut.page.wisp_lanterns.7": "初始化此装置的媒质储库时，需手持后对我自己的咒灵使用。该咒灵会消散且无法召回，装置的媒质容量会设为与该咒灵一致，按紫水晶粉向上取整。若需重设此数据（以及其他所有数据与配置），将其单独放在合成方格中合成即可。",
 
-  "oneironaut.page.noosphere_materials.1": "一种奇怪的流体，会搅混进入其中的媒质，并阻止紫水晶晶体的形成。浸在其中时，它会以愉悦的方式刺激我的意识。",
+  "oneironaut.page.noosphere_materials.1": "一种奇怪的流体，会搅混进入其中的媒质，并阻止晶体的形成。浸在其中时，它会以愉悦的方式刺激我的意识。$(br2)我总能在这种流体中发现四处漂浮的碎纸。也许只要细致研究，就能发现有意思的东西。",
   "oneironaut.page.noosphere_materials.2": "主要由媒质构成的岩石，原理不明。可合成法术环方块。",
   "oneironaut.page.noosphere_materials.3.title": "伪紫水晶",
   "oneironaut.page.noosphere_materials.3": "一大块媒质晶体，与紫水晶类似但不完全相同。触摸时会有种嗡鸣感，就好像媒质在刺激神经一般。不加以特殊措施直接破坏会将其破碎为 1 到 4 块碎片。",
@@ -212,7 +212,7 @@
   "oneironaut.page.mindrender.2": "接受带有锋利魔咒的物品，或放有此类物品的物品展示框，并将锋利转换为同等级的意识撕裂。消耗由魔咒等级决定，目标为书时额外消耗 50%%。",
   "oneironaut.page.lore.treatise1.1": "虽然施放咒术时能直接产生大多数 iota，但总会有不够便捷的情况，甚至于无法产生（例如庞大而精确的数和实体 iota）而不得不另辟蹊径。从核心之类的物品中读取 iota 也不错，但大多数情况下这么做需要第三只手，我很明显没有。从外部位置获取 iota 的其他方法也各有各的局限性。",
   "oneironaut.page.lore.treatise1.2": "而在无外部引用手段可用的情况下，所需的 iota 必须直接插入咒术本身。对部分人而言，这么做会有些不合常理。这是因为传统上的咒术是一个图案列表，但图案自己也是一种 iota，一种与$(l:patterns/meta#hexcasting:eval)赫尔墨斯之策略$(/l)（以及同类图案）协同效果很好的 iota。",
-  "oneironaut.page.lore.treatise1.3": "尽管你没法直接把数放到列表里面，然后让它和使用$(l:patterns/numbers)数字之精思$(/l)一样压入栈顶，但有方法能做到。$(br2)最简单（也是最可靠）的方法是$(l:patterns/patterns_as_iotas#hexcasting:escape)考察$(/l)。和手动施法时一样，列表中其后方的任意事物会被转义并直接压入栈顶，而非和平时一样运行，如此就可避免运行非图案导致的事故。",
+  "oneironaut.page.lore.treatise1.3": "尽管你不能直接把数放到列表里面，放入后也不能让它和使用$(l:patterns/numbers)数字之精思$(/l)一样压入栈顶，但其实有方法能做到。$(br2)最简单（也最不可靠）的方法是$(l:patterns/patterns_as_iotas#hexcasting:escape)考察$(/l)。和手动施法时一样，列表中其后方的任意事物会被转义并直接压入栈顶，而非和平时一样运行，如此就可避免运行非图案导致的事故。",
   "oneironaut.page.lore.treatise1.4": "然而，当你位于咒术中超过一层运行深度处（比如循环和嵌套的条件逻辑），转义 iota 所需的考察数量会极速增长。在那些能够由另一咒术运行的事物中，这种方法便不再可靠。",
   "oneironaut.page.lore.treatise1.4.link": "相关的 xkcd",
   "oneironaut.page.lore.treatise1.5": "更为可靠的转义 iota 方法是$(l:patterns/patterns_as_iotas#hexcasting:open_paren)内省$(/l)和$(l:patterns/patterns_as_iotas#hexcasting:close_paren)反思$(/l)。运行图案列表时，内省后方直到相应反思之间（内省和反思不计）的事物会被转义，并以列表形式压入栈顶，不论 iota 的类型如何。然后就可以用合适方式操作此列表，比如用$(l:patterns/lists#hexcasting:splat)群体之拆解$(/l)把列表中各项分别压入栈顶。",
@@ -349,5 +349,23 @@
   "oneironaut.tooltip.wispcapturedevice.nowisp": "没有咒灵。",
   "oneironaut.tooltip.wispcapturedevice.uninitialized": "媒质储库未初始化。",
   "text.oneironaut.lorem_ipsum": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-  "oneironaut.tooltip.lich_media_amount": "储库含有：%s/%s（%s）"
+  "oneironaut.tooltip.lich_media_amount": "储库含有：%s/%s（%s）",
+
+  "oneironaut.conceptmodifier.falsy": "玩家引用修饰：假值",
+  "oneironaut.conceptmodifier.ref_comparison": "玩家引用修饰：比较",
+  "oneironaut.conceptmodifier.gtp_splat": "卓越传送物品栏保护",
+  "oneironaut.conceptmodifier.antierosion": "侵解保护",
+  "oneironaut.conceptmodifier.nobloodcast": "耗血施法保护",
+  "oneironaut.conceptmodifier.keepinv": "保留物品栏",
+  "oneironaut.conceptmodifier.totem": "不死",
+  "oneironaut.conceptmodifier.attribute": "属性修饰",
+
+  "oneironaut.conceptmodifier.attribute.overlay1.positive": "增加",
+  "oneironaut.conceptmodifier.attribute.overlay1.negative": "降低",
+  "oneironaut.conceptmodifier.attribute.overlay2": "，修饰值为%s%%。",
+
+  "oneironaut.conceptmodifier.nocore": "未检测到概念核心。要让修饰件运作，应破坏修饰件并重新放置在核心旁。",
+  "oneironaut.conceptmodifier.nomodifier": "概念修饰符无法初始化。",
+  "oneironaut.conceptmodifier.lens.potency": "强度：%s",
+  "oneironaut.conceptmodifier.lens.comparison": "比较返回值：%s"
 }

--- a/common/src/main/resources/assets/oneironaut/lang/zh_cn.json
+++ b/common/src/main/resources/assets/oneironaut/lang/zh_cn.json
@@ -360,9 +360,8 @@
   "oneironaut.conceptmodifier.totem": "不死",
   "oneironaut.conceptmodifier.attribute": "属性修饰",
 
-  "oneironaut.conceptmodifier.attribute.overlay1.positive": "增加",
-  "oneironaut.conceptmodifier.attribute.overlay1.negative": "降低",
-  "oneironaut.conceptmodifier.attribute.overlay2": "，修饰值为%s%%。",
+  "oneironaut.conceptmodifier.attribute.overlay.positive": "令%s增加%s%%",
+  "oneironaut.conceptmodifier.attribute.overlay.negative": "令%s降低%s%%",
 
   "oneironaut.conceptmodifier.nocore": "未检测到概念核心。要让修饰件运作，应破坏修饰件并重新放置在核心旁。",
   "oneironaut.conceptmodifier.nomodifier": "概念修饰符无法初始化。",


### PR DESCRIPTION
Translations for `conceptmodifier.attribute.overlay` keys didn't use the most common order in Chinese. Attribute modifiers, as most seen in other games' text, tend to go with "let xx increase yy%" or simply "+yy% xx" and "xx +yy%."
This couldn't be done as sign and amount are split in different keys and the latter one isn't branching with respect to sign, thus the current translation is "increase yy, modifying amount is xx%."

This would be better localized if there is an "word order" key, or match branches for both overlay types:
- "Word order" key goes like "%s%s" with overlays as parameters;
- Branch matching goes like `1.positive`, `1.negative`, `2.positive`, `2.negative`.

It does have the same meaning though, so this could be left as what's in this PR.


TL;DR - There's no commonly used correspondence for "by" under this context in Chinese, translation might be a little weird, but still works. Could be solved by changing key composition.